### PR TITLE
Remove misleading sentence from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus/node_exporter)][goreportcard]
 
 Prometheus exporter for hardware and OS metrics exposed by \*NIX kernels, written
-in Go with pluggable metric collectors.
+in Go.
 
 The [WMI exporter](https://github.com/martinlindhe/wmi_exporter) is recommended for Windows users.
 To expose NVIDIA GPU metrics, [prometheus-dcgm


### PR DESCRIPTION
The node_exporter was never intended to be 'pluggable' in the sense that that it supports runtime plugins.

See:
https://github.com/prometheus/node_exporter/issues/364#issuecomment-647988932